### PR TITLE
fix server stopping bug that occurs when id changed in url

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -14,7 +14,7 @@ var middlewareObj = {
   checkCoffeeshopOwnership: function(req, res, next){
     if(req.isAuthenticated()){
       Coffeeshop.findById(req.params.id, function(err, foundCoffeeshop){
-        if(err){
+        if(err || !foundCoffeeshop){
           req.flash("error", "Coffeeshop not found.");
           res.redirect("back");
         } else {
@@ -35,7 +35,8 @@ var middlewareObj = {
  checkCommentOwnership: function(req, res, next){
   if(req.isAuthenticated()){
     Comment.findById(req.params.comment_id, function(err, foundComment){
-      if(err){
+      if(err || !foundComment){
+        req.flash("error", "Comment not found.")
         res.redirect("back");
       } else {
         if(foundComment.author.id.equals(req.user._id)){

--- a/routes/coffeeshops.js
+++ b/routes/coffeeshops.js
@@ -43,8 +43,9 @@ router.get("/:id", function(req,res){
   // find coffeeshop with provided id
   // render show template
   Coffeeshop.findById(req.params.id).populate("comments").exec(function(err, foundCoffeeshop){
-    if(err){
-      console.log(err);
+    if(err || !foundCoffeeshop){
+      req.flash("error", "Coffeeshop not found.");
+      res.redirect("back");
     } else {
      res.render("coffeeshops/show", {coffeeshop: foundCoffeeshop});
    }

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -8,7 +8,8 @@ var middleware = require("../middleware");
 router.get("/new", middleware.isLoggedIn, function(req, res){
   Coffeeshop.findById(req.params.id, function(err, foundCoffeeshop){
     if(err){
-      console.log(err)
+      req.flash("error", "Campground not found");
+      res.redirect("back");
     } else {
       res.render("comments/new", {coffeeshop: foundCoffeeshop});
     }
@@ -18,9 +19,9 @@ router.get("/new", middleware.isLoggedIn, function(req, res){
 //comments create 
 router.post("/", middleware.isLoggedIn, function(req, res){
  Coffeeshop.findById(req.params.id, function(err, coffeeshop){
-  if(err){
-    console.log(err)
-    res.redirect("/coffeeshops");
+  if(err || coffeeshop){
+    req.flash("error", "Campground not found");
+    res.redirect("back");
   } else {
     Comment.create(req.body.comment, function(err, comment){
       if(err){
@@ -40,7 +41,7 @@ router.post("/", middleware.isLoggedIn, function(req, res){
   }
 })
 });
-
+// comment edit
 router.get("/:comment_id/edit", middleware.checkCommentOwnership, function(req, res){
   Comment.findById(req.params.comment_id, function(err, foundComment){
     if(err){
@@ -50,17 +51,23 @@ router.get("/:comment_id/edit", middleware.checkCommentOwnership, function(req, 
     }
   });
 });
-
+// comment update
 router.put("/:comment_id", middleware.checkCommentOwnership, function(req, res){
-  Comment.findByIdAndUpdate(req.params.comment_id, req.body.comment, function(err,updatedComment){
-    if(err){
-      res.redirect("back");
-    } else {
-      res.redirect("/coffeeshops/" + req.params.id);
+  Coffeeshop.findById(req.params.id, function(err, foundCoffeeshop){
+    if(err || !foundCoffeeshop){
+      req.flash("error", "No coffeeshop found.");
+      return res.redirect("back");
     }
-  })
+    Comment.findByIdAndUpdate(req.params.comment_id, req.body.comment, function(err,updatedComment){
+      if(err){
+        res.redirect("back");
+      } else {
+        res.redirect("/coffeeshops/" + req.params.id);
+      }
+    });
+  });
 });
-
+// comment delete
 router.delete("/:comment_id", middleware.checkCommentOwnership, function(req, res){
   Comment.findByIdAndRemove(req.params.comment_id, function(err){
     if(err){


### PR DESCRIPTION
- Bug stops the server when the user changes the comment or coffeeshop id in the url. If the id is still a valid length , findById will return a null from mongodb. Using that "found coffeeshop/comment" in the callback will throw and error and crash the server.
- Changing the comment or coffeeshop id in the url to an id of the wrong length did not produce an error message but will throw a cast error in the console.
- Added logic to middleware, comment and coffeeshop routes that check whether mongodb has returned null before continuing. 